### PR TITLE
Get all timesheets

### DIFF
--- a/openapi.edn
+++ b/openapi.edn
@@ -171,6 +171,33 @@
     :responses
     {201 {}}}}
 
+  "/users/{userId}/timesheets"
+  {:parameters
+   [{:name "userId"
+     :in "path"
+     :required true
+     :description "users three letter code"
+     :schema {:type "string"}}]
+   :get
+   {:summary "Returns a users timesheet entries"
+    :operationId "getTimesheets"
+    :tags ["People"]
+    :responses
+    {200
+     {:juxt.site.alpha/query
+      #juxt.site.alpha/as-str
+      {:find [(pull timesheet [*])]
+       :where
+       [[(str {:juxt.site.alpha/ref [:juxt.site.alpha/base-uri]}
+              "/_site/users/"
+              {:in "path" :name "userId"})
+         user]
+        [timesheet :juxt.site.alpha/type "Timesheet"]
+        [timesheet :juxt.pass.alpha/user user]]}
+      :content
+      {"application/json"
+       {:schema {}}}}}}}
+
   "/holidays"
   {:get
    {:summary "Returns a list of all holidays"

--- a/src/cljs/juxt/home/card/subscriptions.cljs
+++ b/src/cljs/juxt/home/card/subscriptions.cljs
@@ -141,14 +141,20 @@
  ::my-holidays
  :<- [::user-info]
  :<- [::holidays]
- (fn [[{id :username} holidays]]
+ (fn [[{id :id} holidays]]
    (get holidays id)))
+
+(rf/reg-sub
+ ::my-timesheets
+ (fn [db]
+   (:my-timesheets db)))
 
 (rf/reg-sub
  ::my-events
  :<- [::my-holidays]
- (fn [hols]
-   hols))
+ :<- [::my-timesheets]
+ (fn [[hols timesheets]]
+   (into hols timesheets)))
 
 (rf/reg-sub
  ::raw-people


### PR DESCRIPTION
I've opted for getting all timesheets for now - when we know more about the rules in site we could change this. My understanding though is that the rules would or could stop a non-admin user from seeing others timesheets.